### PR TITLE
Fix missing page title

### DIFF
--- a/resources/js/components/Tool.vue
+++ b/resources/js/components/Tool.vue
@@ -92,6 +92,11 @@
         mounted() {
             this.getPasswordSize()
         },
+        metaInfo() {
+    	    return {
+            title: this.__('Reset My Password')
+            }
+        },
         methods: {
             getPasswordSize: function () {
                 Nova.request().get('/nova-vendor/nova-password-reset/min-password-size').then(response => {


### PR DESCRIPTION
This PR adds a default page title while using this tool, because the page title was previously empty. 